### PR TITLE
ZIP 1014 Volatility Reserve clarifications

### DIFF
--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -272,9 +272,12 @@ Funding Target and Volatility Reserve
 Each Dev Fund slice has a Funding Target, initially US $700,000 for each
 slice. At the end of each calendar month, the fair market value of the Dev
 Fund ZEC received during that month will be computed, and the excess over
-the Funding Target will be put into a dedicated Volatility Reserve account
-by the funds' recipient.
+the Funding Target will be deposited into a dedicated Volatility Reserve
+account by the funds' recipient.
 
+Each slice has its own separate Volatility reserve account, owned and
+managed by the recipient (ECC or ZF), but limited in how it may be used
+(i.e., analogously to some types of retirement or trust accounts).
 Funds may be withdrawn from the Volatility Reserve account only by that same
 party, in months where the aforementioned monthly ZEC value falls short of
 the Funding Target, and only to the extent needed to cover that shortfall.
@@ -292,6 +295,14 @@ Dev Fund ZEC that has been received, not placed in the Volatility Reserve,
 and has not yet been used or disbursed, will be kept by the corresponding
 party (as ZEC, or sold and invested) for later use under the terms of the
 corresponding slice.
+
+Note that grantees of Major Grants are not directly subject to the Funding
+Target, and do not have to manage a Volatility Reserve account; this is
+addressed upstream by the Zcash Foundation, which awards these grants. The
+hope is that the Foundation-managed Zfnd-MG Volatility Reserve will ultimately
+form a large long-term "endowment" pool that cushions the volatility for the
+various grantees, so grantees can focus on their work instead of hedging
+short-term price risks.
 
 Irrevocable obligations to the above must be made by the recipients (e.g.,
 using their Operating Agreements or by receiving the slice as Restricted


### PR DESCRIPTION
Address a FAQ on how Volatility Reserve is meant to work in ZIP 1014. No normative changes.
